### PR TITLE
Bug fix 1

### DIFF
--- a/src/components/features/PlayVsComputerModal.vue
+++ b/src/components/features/PlayVsComputerModal.vue
@@ -17,13 +17,20 @@
 
       <!-- Player Name Input -->
       <div class="mb-4">
-        <label for="playerName" class="block font-semibold mb-2">Player Name:</label>
+        <label for="playerName" class="block font-semibold mb-2">
+          Player Name: <span class="text-red-500">*</span>
+        </label>
         <input
           id="playerName"
+          ref="playerNameInput"
           type="text"
           v-model="playerName"
-          class="w-full p-2 rounded border border-gray-500 bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+          :class="[
+            'w-full p-2 rounded bg-gray-200 text-black focus:outline-none focus:ring-2',
+            playerNameError ? 'border-red-500 focus:ring-red-500' : 'border-gray-500 focus:ring-blue-500',
+          ]"
         />
+        <p v-if="playerNameError" class="text-red-500 text-sm mt-2">Player Name is required.</p>
       </div>
 
       <!-- Choose Side -->
@@ -67,8 +74,8 @@
       <!-- Begin Button -->
       <div class="text-center mt-6">
         <button
-          class="btn bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-          @click="startGame"
+          class="btn"
+          @click="validateAndStart"
         >
           Begin
         </button>
@@ -88,6 +95,7 @@ export default {
   data() {
     return {
       playerName: "",
+      playerNameError: false,  
       side: "black",
       selectedAvatar: null as Avatar | null,
       avatars: [
@@ -103,33 +111,49 @@ export default {
       ],  
     };
   },
-  methods: {
-  startGame() {
-    if (!this.selectedAvatar) {
-      alert("Please select an avatar before starting the game.");
-      return;
+  created() {
+    if (this.avatars.length > 0) {
+      this.selectedAvatar = this.avatars[0];
     }
-
-    const computerAvatar = this.avatars[Math.floor(Math.random() * this.avatars.length)];
-
-    const playerData = {
-      name: this.playerName || "Player",
-      side: this.side,
-      avatar: this.selectedAvatar,
-    };
-
-    const computerData = {
-      name: "Computer",
-      side: this.side === "black" ? "white" : "black",
-      avatar: computerAvatar,
-    };
-
-    sessionStorage.setItem("playerData", JSON.stringify(playerData));
-    sessionStorage.setItem("computerData", JSON.stringify(computerData));
-
-    this.$router.push("/game/computer");
   },
-},
+  methods: {
+    validateAndStart() {
+      this.playerNameError = this.playerName.trim() === "";
+
+      if (this.playerNameError) {
+        // Focus the input field if validation fails
+        (this.$refs.playerNameInput as HTMLInputElement)?.focus();
+        return;
+      }
+
+      if (!this.selectedAvatar) {
+        alert("Please select an avatar before starting the game.");
+        return;
+      }
+
+      this.startGame();
+    },
+    startGame() {
+      const computerAvatar = this.avatars[Math.floor(Math.random() * this.avatars.length)];
+
+      const playerData = {
+        name: this.playerName || "Player",
+        side: this.side,
+        avatar: this.selectedAvatar,
+      };
+
+      const computerData = {
+        name: "Computer",
+        side: this.side === "black" ? "white" : "black",
+        avatar: computerAvatar,
+      };
+
+      sessionStorage.setItem("playerData", JSON.stringify(playerData));
+      sessionStorage.setItem("computerData", JSON.stringify(computerData));
+
+      this.$router.push("/game/computer");
+    },
+  },
 };
 </script>
 


### PR DESCRIPTION
# Pull Request

## Type of Change

- [x] bug fix 🐛
- [x] styling 🎨

<!--- Delete any above that do not apply to this PR -->

## Description
<!--- Describe your changes in detail -->

This pull request introduces several key enhancements and bug fixes to the PlayVsComputer functionality, alongside improvements in the user experience and code maintainability. The changes include validation for player input, dynamic UI updates, and improvements to the battle logic and state management.

# Key Changes

### 1. Player Name Validation
- Added a required **Player Name** field with a red `*` indicator for better user guidance.
- Displays an error message (`Player Name is required.`) if the field is left empty.
- The input box turns red to provide a visual cue when validation fails.

---

### 2. Avatar Selection Enhancements
- Defaulted the selected avatar to the first one in the list to avoid empty selections.
- Ensures an avatar must be chosen before proceeding with the game.

---

### 3. Begin Button Logic
- Replaced the `startGame` method with `validateAndStart` to handle form validation before game initiation.
- Ensures both **Player Name** and **Avatar** are valid before transitioning to the game.

---

### 4. Improved Game Reset Logic
- Resolved issues with resetting the game state:
  - Reset `isButtonDisabled` to `false`.
  - Re-initialized player and computer pieces upon reset.
- Ensures the game board and state are fully refreshed for a new session.

---

### 5. Battle Button Logic
- Enhanced the **Battle** button to disable during animations and prevent multiple clicks within a 1-second delay.
- Added conditions to ensure the button only activates with valid active pieces.

---

### 6. Dynamic UI Updates
- Updated **Pieces** components to hide when no pieces are available (`v-if` logic added).
- Simplified conditional rendering for dynamic battlefields and pieces visibility.

---

### 7. Improved Battle Logic
- Adjusted delays and ensured the **Battle** button resets correctly after the last turn.
- Fixed edge cases where scores and states could become inconsistent when clicking rapidly.

---

### 8. Winner Modal
- Enhanced the logic to handle displaying the winner, their avatar, and final score seamlessly.
- Included buttons for:
  - **Play Again** (resets game).
  - **Back to Home** (redirects to home screen).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#24 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
